### PR TITLE
Update .Rprofile

### DIFF
--- a/dev/.Rprofile
+++ b/dev/.Rprofile
@@ -1,5 +1,6 @@
-ifelse(!dir.exists(file.path("~", "R", "x86_64-pc-linux-gnu-library", "3.4")), 
-       dir.create(file.path("~", "R", "x86_64-pc-linux-gnu-library", "3.4"), recursive = TRUE), 
-       FALSE)
-
-.libPaths(c(file.path("~", "R", "x86_64-pc-linux-gnu-library", "3.4") , .libPaths()))
+if (!dir.exists(paths = file.path("~", "R", "x86_64-pc-linux-gnu-library", "3.4"))) {
+  dir.create(path = file.path("~", "R", "x86_64-pc-linux-gnu-library", "3.4"),
+             recursive = TRUE)
+  }
+.libPaths(new = c(file.path("~", "R", "x86_64-pc-linux-gnu-library", "3.4"),
+                  .libPaths()))

--- a/dev/.Rprofile
+++ b/dev/.Rprofile
@@ -1,8 +1,9 @@
-for v in c("3.4", "3.5") {
-  if (!dir.exists(paths = file.path("~", "R", "x86_64-pc-linux-gnu-library", v))) {
-    dir.create(path = file.path("~", "R", "x86_64-pc-linux-gnu-library", v),
-               recursive = TRUE)
-    }
-  .libPaths(new = c(file.path("~", "R", "x86_64-pc-linux-gnu-library", v),
-                    .libPaths()))
+path <- file.path("~", "R", "x86_64-pc-linux-gnu-library",
+                  paste(version$major,
+                        substr(x = version$minor, start = 1L, stop = 1L),
+                        sep = "."))
+if (!dir.exists(paths = path)) {
+  dir.create(path = path, recursive = TRUE)
   }
+.libPaths(new = c(path, .libPaths()))
+rm(list = c("path"))

--- a/dev/.Rprofile
+++ b/dev/.Rprofile
@@ -1,6 +1,8 @@
-if (!dir.exists(paths = file.path("~", "R", "x86_64-pc-linux-gnu-library", "3.4"))) {
-  dir.create(path = file.path("~", "R", "x86_64-pc-linux-gnu-library", "3.4"),
-             recursive = TRUE)
+for v in c("3.4", "3.5") {
+  if (!dir.exists(paths = file.path("~", "R", "x86_64-pc-linux-gnu-library", v))) {
+    dir.create(path = file.path("~", "R", "x86_64-pc-linux-gnu-library", v),
+               recursive = TRUE)
+    }
+  .libPaths(new = c(file.path("~", "R", "x86_64-pc-linux-gnu-library", v),
+                    .libPaths()))
   }
-.libPaths(new = c(file.path("~", "R", "x86_64-pc-linux-gnu-library", "3.4"),
-                  .libPaths()))


### PR DESCRIPTION
- Avoids getting the FALSE output on the console every time a session starts after the first time.
- Temporary improvement. Better solution would be to migrate the logic here to `Rprofile.site`.

Side note, why is the path `v3.4` when the R version for those containers is `v3.5.1`?