### PR TITLE
Projects and Teams

### DIFF
--- a/db/data/projects.json
+++ b/db/data/projects.json
@@ -1,0 +1,76 @@
+[{
+        "project": "ARMY_ARI1",
+        "members": [
+            "dmh6am",
+            "jrg3bs",
+            "sak9tr",
+            "sss5sc"
+        ]
+    },
+    {
+        "project": "Inova_Fairfax",
+        "members": [
+            "kb7hp",
+            "jrg3bs",
+            "sak9tr",
+            "sss5sc",
+            "tp2sk",
+            "jt4jt"
+        ]
+    },
+    {
+        "project": "USDA_BB",
+        "members": [
+            "ads7fg",
+            "dtn2ep",
+            "jrg3bs",
+            "nak3t",
+            "sss5sc",
+            "tp2sk"
+        ]
+    },
+    {
+        "project": "NCSES_BI",
+        "members": [
+            "aka3v",
+            "camb98",
+            "dtn2ep",
+            "ieuan97",
+            "gk8yj",
+            "nak3t",
+            "xiang97"
+        ]
+    },
+    {
+        "project": "NCSES_RnD",
+        "members": [
+            "aka3v",
+            "jt9sz",
+            "sc2pg",
+            "sp3sd",
+            "sss5sc"
+        ]
+    },
+    {
+        "project": "NCSES_OSS",
+        "members": [
+            "ads7fg",
+            "ci3uz",
+            "ent4pn",
+            "gk8yj",
+            "jbs3hp",
+            "kb7hp"
+        ]
+    },
+    {
+        "project": "NCSES_STW",
+        "members": [
+            "dtn2ep",
+            "jbs3hp",
+            "nr3xe",
+            "sc2pg",
+            "sm9dv",
+            "val7zv"
+        ]
+    }
+]


### PR DESCRIPTION
- This dataset excludes projects that do not use the SDAD infrastructure (MINERVA, ARI2, Visualization).
- It includes both SDAD team and external collaborators.